### PR TITLE
Use -www flag as directory path & ENTRYPOINT for Dockerfile.build

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -14,4 +14,4 @@ RUN go mod download
 
 RUN go build -o /client-speedtest-webtransport-go
 
-CMD [ "/server-speedtest-webtransport-go" ]
+ENTRYPOINT [ "/server-speedtest-webtransport-go" ]

--- a/main.go
+++ b/main.go
@@ -72,8 +72,6 @@ func (s *NDTServer) endTransferAndSendStats(kind ndt.TransferKind, sess *webtran
 }
 
 func main() {
-	htmlDir := "."
-
 	www := flag.String("www", "www", "HTTP root directory")
 	certFile := flag.String("cert", "cert.pem", "path to the certificate")
 	keyFile := flag.String("key", "key.pem", "path to the private key")
@@ -92,7 +90,7 @@ func main() {
 
 	// The ndt7 listener serving up NDT7 tests, likely on standard ports.
 	ndt7Mux := http.NewServeMux()
-	ndt7Mux.Handle(*www, http.FileServer(http.Dir(htmlDir)))
+	ndt7Mux.Handle("/", http.FileServer(http.Dir(*www)))
 	// create a new webtransport.Server, listening on (UDP) port 443
 	server := NDTServer{
 		stats: ndt.Stats{


### PR DESCRIPTION
This PR includes two changes needed to run the server on M-Lab's sandbox servers.

* Now the server uses `-www` flag value as the directory path for `http.FileServer(http.Dir(*www))` allowing the data directory to change at runtime.
* Now `Dockerfile.build` uses `ENTRYPOINT` so the k8s configuration only requires flags for the entrypoint command.